### PR TITLE
Correcting PayPal Redirect URL

### DIFF
--- a/Samples/AdaptiveAccountsSampleApp/Web.config
+++ b/Samples/AdaptiveAccountsSampleApp/Web.config
@@ -28,6 +28,6 @@
 		<compilation debug="true"/>
   </system.web>
 	<appSettings>
-		<add key="PAYPAL_REDIRECT_URL" value="https://www.sandbox.paypal.com/webscr&amp;cmd="/>
+		<add key="PAYPAL_REDIRECT_URL" value="https://www.sandbox.paypal.com/webscr?cmd="/>
 	</appSettings>
 </configuration>


### PR DESCRIPTION
The ampersand in the redirect was causing instability. Corrected to a ? in the URL, resolving issue.